### PR TITLE
docs: fix 'my_preload' typos in fastboot commands

### DIFF
--- a/docs/convert_guide_en.md
+++ b/docs/convert_guide_en.md
@@ -137,5 +137,5 @@ Two option are available to obtain the firmware:
     ```
     ```shell
     fastboot flash my_company my_company.img
-    fastboot flash my_prelaod my_prelaod.img
+    fastboot flash my_preload my_preload.img
     ```

--- a/docs/convert_guide_zh.md
+++ b/docs/convert_guide_zh.md
@@ -137,5 +137,5 @@
     ```
     ```shell
     fastboot flash my_company my_company.img
-    fastboot flash my_prelaod my_prelaod.img
+    fastboot flash my_preload my_preload.img
     ```


### PR DESCRIPTION
Fixed the misspelling of 'my_preload' (written as 'my_prelaod') in two separate files. This prevents users from copying the code and encountering 'partition not found' errors when running the fastboot flash commands.